### PR TITLE
[Debug Feature] Add interface to get default size of the variable can…

### DIFF
--- a/clang/runtime/dpct-rt/include/debug/json.hpp
+++ b/clang/runtime/dpct-rt/include/debug/json.hpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <string.h>
 #include <sys/types.h>
 #include <type_traits>
 #include <utility>

--- a/clang/test/dpct/debug_test/vector_add/sycl_ref/vectorAdd_build_in_type.cpp.dp.cpp
+++ b/clang/test/dpct/debug_test/vector_add/sycl_ref/vectorAdd_build_in_type.cpp.dp.cpp
@@ -134,10 +134,16 @@ int main(void) try {
   int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
   printf("CUDA kernel launch with %d blocks of %d threads\n", blocksPerGrid,
          threadsPerBlock);
+
   dpct::experimental::gen_prolog_API_CP(
-      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A, 0,
-      TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0,
-      TYPE_SHCEMA_008, (long)numElements, 0);
+      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006,
+      (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006),
+      TYPE_SHCEMA_007, (long)d_C,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008,
+      (long)numElements,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
+
   /*
   DPCT1049:0: The work-group size passed to the SYCL kernel may exceed the
   limit. To get the device limit, query info::device::max_work_group_size.
@@ -150,10 +156,15 @@ int main(void) try {
       [=](sycl::nd_item<3> item_ct1) {
         vectorAdd(d_A, d_B, d_C, numElements, item_ct1);
       });
+
   dpct::experimental::gen_epilog_API_CP(
-      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A, 0,
-      TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0,
-      TYPE_SHCEMA_008, (long)numElements, 0);
+      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006,
+      (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006),
+      TYPE_SHCEMA_007, (long)d_C,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008,
+      (long)numElements,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
 
   /*
   DPCT1010:6: SYCL uses exceptions to report errors and does not use the error

--- a/clang/test/dpct/debug_test/vector_add/vectorAdd_build_in_type.cpp
+++ b/clang/test/dpct/debug_test/vector_add/vectorAdd_build_in_type.cpp
@@ -154,9 +154,9 @@ int main(void) {
   int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
   printf("CUDA kernel launch with %d blocks of %d threads\n", blocksPerGrid,
          threadsPerBlock);
-  dpct::experimental::gen_prolog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, 0, TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0, TYPE_SHCEMA_008, (long)numElements, 0);
+  dpct::experimental::gen_prolog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006, (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006), TYPE_SHCEMA_007, (long)d_C, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008, (long)numElements, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
   vectorAdd<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_C, numElements);
-  dpct::experimental::gen_epilog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, 0, TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0, TYPE_SHCEMA_008, (long)numElements, 0);
+  dpct::experimental::gen_epilog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006, (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006), TYPE_SHCEMA_007, (long)d_C, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008, (long)numElements, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
 
   err = cudaGetLastError();
 

--- a/clang/test/dpct/debug_test/vector_add_class/sycl_ref/vectorAdd_obj_data.dp.cpp
+++ b/clang/test/dpct/debug_test/vector_add_class/sycl_ref/vectorAdd_obj_data.dp.cpp
@@ -177,10 +177,14 @@ int main(void) try {
   int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
   printf("CUDA kernel launch with %d blocks of %d threads\n", blocksPerGrid,
          threadsPerBlock);
-  dpct::experimental::gen_prolog_API_CP(
-      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A, 0,
-      TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0,
-      TYPE_SHCEMA_008, (long)numElements, 0);
+   dpct::experimental::gen_prolog_API_CP(
+      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006,
+      (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006),
+      TYPE_SHCEMA_007, (long)d_C,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008,
+      (long)numElements,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
   /*
   DPCT1049:0: The work-group size passed to the SYCL kernel may exceed the
   limit. To get the device limit, query info::device::max_work_group_size.
@@ -194,9 +198,13 @@ int main(void) try {
         vectorAdd(d_A, d_B, d_C, numElements, item_ct1);
       });
   dpct::experimental::gen_epilog_API_CP(
-      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A, 0,
-      TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0,
-      TYPE_SHCEMA_008, (long)numElements, 0);
+      "vectorAdd:vecotr.cu:[221]:", &q_ct1, TYPE_SHCEMA_005, (long)d_A,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006,
+      (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006),
+      TYPE_SHCEMA_007, (long)d_C,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008,
+      (long)numElements,
+      dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
 
   /*
   DPCT1010:6: SYCL uses exceptions to report errors and does not use the error

--- a/clang/test/dpct/debug_test/vector_add_class/vectorAdd_obj_data.cu
+++ b/clang/test/dpct/debug_test/vector_add_class/vectorAdd_obj_data.cu
@@ -197,9 +197,9 @@ int main(void) {
   int blocksPerGrid = (numElements + threadsPerBlock - 1) / threadsPerBlock;
   printf("CUDA kernel launch with %d blocks of %d threads\n", blocksPerGrid,
          threadsPerBlock);
-  dpct::experimental::gen_prolog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, 0, TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0, TYPE_SHCEMA_008, (long)numElements, 0);
+  dpct::experimental::gen_prolog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006, (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006), TYPE_SHCEMA_007, (long)d_C, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008, (long)numElements, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
   vectorAdd<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_C, numElements);
-  dpct::experimental::gen_epilog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, 0, TYPE_SHCEMA_006, (long)d_B, 0, TYPE_SHCEMA_007, (long)d_C, 0, TYPE_SHCEMA_008, (long)numElements, 0);
+  dpct::experimental::gen_epilog_API_CP("vectorAdd:vecotr.cu:[221]:", 0, TYPE_SHCEMA_005, (long)d_A, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_005), TYPE_SHCEMA_006, (long)d_B, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_006), TYPE_SHCEMA_007, (long)d_C, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_007), TYPE_SHCEMA_008, (long)numElements, dpct::experimental::get_size_of_schema(TYPE_SHCEMA_008));
 
   err = cudaGetLastError();
 


### PR DESCRIPTION
… be printed.

The default is 0 that means to use type size in the shcmea size as the variable size. User can directly change the API call to a literal number.